### PR TITLE
Add stock management to Product entity

### DIFF
--- a/Shop/Domain/Entities/Product.cs
+++ b/Shop/Domain/Entities/Product.cs
@@ -8,17 +8,46 @@ public class Product
     public string Picture { get; private set; }
     public string Title { get; private set; }
     public string Description { get; private set; }
-    public Price Price { get; private set; } 
+    public Price Price { get; private set; }
+    public int StockQuantity { get; private set; } 
     
     private Product() { }
 
-    public Product(string picture, string title, string description, Price price)
+    public Product(string picture, string title, string description, Price price, int initialStock)
     {
         Id = Guid.NewGuid();
         Picture = picture;
         Title = title;
         Description = description;
         Price = price;
+        StockQuantity = initialStock;
+    }
+    
+    public void AddStock(int quantity)
+    {
+        if (quantity <= 0)
+        {
+            throw new ArgumentException("Quantity to add must be greater than zero.");
+        }
+        StockQuantity += quantity;
+    }
+    
+    public void ReduceStock(int quantity)
+    {
+        if (quantity <= 0)
+        {
+            throw new ArgumentException("Quantity to reduce must be greater than zero.");
+        }
+        if (StockQuantity - quantity < 0)
+        {
+            throw new InvalidOperationException("Not enough stock available.");
+        }
+        StockQuantity -= quantity;
+    }
+    
+    public bool IsInStock(int quantity)
+    {
+        return StockQuantity >= quantity;
     }
 }
 

--- a/Shop/Infrastructure/DataAccess/Migrations/20241020141258_AddStockToProduct.Designer.cs
+++ b/Shop/Infrastructure/DataAccess/Migrations/20241020141258_AddStockToProduct.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Shop.Infrastructure.DataAccess;
 
@@ -11,9 +12,11 @@ using Shop.Infrastructure.DataAccess;
 namespace Shop.Infrastructure.DataAccess.Migrations
 {
     [DbContext(typeof(ShopDbContext))]
-    partial class ShopDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241020141258_AddStockToProduct")]
+    partial class AddStockToProduct
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Shop/Infrastructure/DataAccess/Migrations/20241020141258_AddStockToProduct.cs
+++ b/Shop/Infrastructure/DataAccess/Migrations/20241020141258_AddStockToProduct.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Shop.Infrastructure.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStockToProduct : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "StockQuantity",
+                table: "Products",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StockQuantity",
+                table: "Products");
+        }
+    }
+}

--- a/Shop/Infrastructure/DataAccess/ShopDbContext.cs
+++ b/Shop/Infrastructure/DataAccess/ShopDbContext.cs
@@ -19,6 +19,10 @@ public class ShopDbContext : DbContext
     {
         modelBuilder.Entity<Product>()
             .OwnsOne(p => p.Price, p => { p.Property(x => x.Value).HasColumnName("Price").IsRequired(); });
+        
+        modelBuilder.Entity<Product>()
+            .Property(p => p.StockQuantity)
+            .IsRequired(); 
 
         modelBuilder.Entity<BasketItem>()
             .HasKey(b => b.Id);
@@ -37,8 +41,9 @@ public class ShopDbContext : DbContext
             .Property(d => d.Title)
             .HasMaxLength(100)
             .IsRequired();
-        
-        
-        modelBuilder.Entity<Discount>().OwnsOne(p => p.Value, p => { p.Property(x => x.Value).HasColumnName("Value").IsRequired(); });
+
+
+        modelBuilder.Entity<Discount>().OwnsOne(p => p.Value,
+            p => { p.Property(x => x.Value).HasColumnName("Value").IsRequired(); });
     }
 }


### PR DESCRIPTION
- Introduced `StockQuantity` property to the `Product` entity.
- Added methods to manage stock: `AddStock`, `ReduceStock`, and `IsInStock`.
- Updated constructor to initialize stock with `initialStock` parameter.
- Created migration to include `StockQuantity` in the database.
- Updated `ShopDbContext` to enforce `StockQuantity` as a required field in `Product`.